### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-ton-linux-x86-64-appimage.yml
+++ b/.github/workflows/build-ton-linux-x86-64-appimage.yml
@@ -2,6 +2,9 @@ name: Ubuntu TON build (AppImages, x86-64)
 
 on: [push,workflow_dispatch,workflow_call]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Potential fix for [https://github.com/RFOF-NETWORK-Ready-for-our-future/Telegram-Contes-Blockchain-round-1/security/code-scanning/1](https://github.com/RFOF-NETWORK-Ready-for-our-future/Telegram-Contes-Blockchain-round-1/security/code-scanning/1)

To fix the issue, add a `permissions` block at the top of the workflow file, applying minimal `read` permissions to repository contents. Since the workflow does not appear to require `write` permissions, specifying `contents: read` is sufficient. This change ensures the workflow adheres to the principle of least privilege by explicitly limiting the `GITHUB_TOKEN` permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
